### PR TITLE
Backfill tags across existing notes

### DIFF
--- a/notes/2026-04-10-agent-ownership-and-names.md
+++ b/notes/2026-04-10-agent-ownership-and-names.md
@@ -6,6 +6,9 @@ status: published
 format: summary
 related:
   - 2026-04-10-harness-engineering-dialogue.md
+tags:
+  - agent-ownership
+  - personas
 ---
 
 # Agent ownership and the naming of Piers and Tully

--- a/notes/2026-04-10-harness-engineering-dialogue.md
+++ b/notes/2026-04-10-harness-engineering-dialogue.md
@@ -9,6 +9,9 @@ sources:
   - https://openai.com/index/harness-engineering/
   - https://github.com/openai/symphony
   - https://martinfowler.com/articles/exploring-gen-ai/harness-engineering.html
+tags:
+  - harness-engineering
+  - claude-code
 ---
 
 # Two Perspectives on Harness Engineering in TDF26

--- a/notes/2026-04-10-personas-vs-subagents.md
+++ b/notes/2026-04-10-personas-vs-subagents.md
@@ -6,6 +6,10 @@ status: published
 format: explainer
 related:
   - 2026-04-10-agent-ownership-and-names.md
+tags:
+  - claude-code
+  - personas
+  - subagents
 ---
 
 # Personas versus subagents

--- a/notes/2026-04-11-nested-ooda-loops.md
+++ b/notes/2026-04-11-nested-ooda-loops.md
@@ -6,6 +6,9 @@ status: published
 format: summary
 related:
   - 2026-04-10-agent-ownership-and-names.md
+tags:
+  - ooda
+  - ceremonies
 ---
 
 # Loops inside loops: OODA at multiple scales

--- a/notes/2026-04-11-parallel-branches-parallel-sessions.md
+++ b/notes/2026-04-11-parallel-branches-parallel-sessions.md
@@ -7,6 +7,10 @@ format: summary
 related:
   - 2026-04-11-nested-ooda-loops.md
   - 2026-04-10-personas-vs-subagents.md
+tags:
+  - git
+  - session-management
+  - claude-code
 ---
 
 # Parallel branches, parallel sessions

--- a/notes/2026-04-20-ceremonies-on-the-ooda-loop.md
+++ b/notes/2026-04-20-ceremonies-on-the-ooda-loop.md
@@ -6,6 +6,10 @@ status: published
 format: summary
 related:
   - 2026-04-11-nested-ooda-loops.md
+tags:
+  - ooda
+  - ceremonies
+  - retrospective
 ---
 
 # Ceremonies on the OODA loop: retro, planning, sprint

--- a/notes/2026-04-20-git-status-as-load-bearing-signal.md
+++ b/notes/2026-04-20-git-status-as-load-bearing-signal.md
@@ -6,6 +6,9 @@ status: published
 format: summary
 related:
   - 2026-04-20-hygiene-and-retrospective.md
+tags:
+  - git
+  - hygiene
 ---
 
 # Keeping `git status` load-bearing

--- a/notes/2026-04-20-hygiene-and-retrospective.md
+++ b/notes/2026-04-20-hygiene-and-retrospective.md
@@ -7,6 +7,10 @@ format: summary
 related:
   - 2026-04-20-git-status-as-load-bearing-signal.md
   - 2026-04-20-session-end-at-seams.md
+tags:
+  - hygiene
+  - retrospective
+  - ceremonies
 ---
 
 # Hygiene and retrospective: different mechanisms

--- a/notes/2026-04-20-last-responsible-moment-and-permanence.md
+++ b/notes/2026-04-20-last-responsible-moment-and-permanence.md
@@ -8,6 +8,9 @@ sources:
   - https://www.oreilly.com/library/view/lean-software-development/0321150783/
 related:
   - 2026-04-20-ceremonies-on-the-ooda-loop.md
+tags:
+  - decision-making
+  - permanence
 ---
 
 # The last responsible moment under a permanence rule

--- a/notes/2026-04-20-session-end-at-seams.md
+++ b/notes/2026-04-20-session-end-at-seams.md
@@ -7,6 +7,9 @@ format: summary
 related:
   - 2026-04-20-hygiene-and-retrospective.md
   - 2026-04-11-parallel-branches-parallel-sessions.md
+tags:
+  - hygiene
+  - session-management
 ---
 
 # Deliberate session-end at workstream seams


### PR DESCRIPTION
## Summary

- Establishes a shared tag vocabulary (13 tags) across the ten existing notes in `notes/`, which previously defined zero `tags:` fields even though `CLAUDE.md` documents the field as available
- Each note carries 2–3 tags; most tags recur across at least two notes, giving a future tag-navigation page something substantive to cluster on

## Tag vocabulary

`agent-ownership`, `ceremonies`, `claude-code`, `decision-making`, `git`, `harness-engineering`, `hygiene`, `ooda`, `permanence`, `personas`, `retrospective`, `session-management`, `subagents`.

Five tags are currently single-use (`agent-ownership`, `harness-engineering`, `subagents`, `decision-making`, `permanence`) — kept on the basis that each anchors a named concept likely to recur as more notes land, not folded into broader buckets.

## Per-note mapping

| Note | Tags |
|---|---|
| 2026-04-10 agent-ownership-and-names | `agent-ownership`, `personas` |
| 2026-04-10 harness-engineering-dialogue | `harness-engineering`, `claude-code` |
| 2026-04-10 personas-vs-subagents | `claude-code`, `personas`, `subagents` |
| 2026-04-11 nested-ooda-loops | `ooda`, `ceremonies` |
| 2026-04-11 parallel-branches-parallel-sessions | `git`, `session-management`, `claude-code` |
| 2026-04-20 ceremonies-on-the-ooda-loop | `ooda`, `ceremonies`, `retrospective` |
| 2026-04-20 git-status-as-load-bearing-signal | `git`, `hygiene` |
| 2026-04-20 hygiene-and-retrospective | `hygiene`, `retrospective`, `ceremonies` |
| 2026-04-20 last-responsible-moment-and-permanence | `decision-making`, `permanence` |
| 2026-04-20 session-end-at-seams | `hygiene`, `session-management` |

## Test plan

- [x] GitHub Pages build succeeds on merge to `main`
- [x] Spot-check a rendered note page to confirm the new frontmatter does not leak into the rendered body
- [x] No visible change to any page (tags are currently not surfaced in layout; this change only populates the field)

🤖 Generated with [Claude Code](https://claude.com/claude-code)