### PR TITLE
Add /tags/ browse page grouping notes by topic

### DIFF
--- a/notes/index.md
+++ b/notes/index.md
@@ -6,7 +6,7 @@ permalink: /notes/
 
 Reflective writing about the practice itself. Retrospectives, dialogues, explainers of how the tools actually work, and other working notes that do not yet fit on a principles page.
 
-Subscribe via [RSS feed]({{ site.baseurl }}/notes/feed.xml).
+Subscribe via [RSS feed]({{ site.baseurl }}/notes/feed.xml). Browse by [tag]({{ site.baseurl }}/tags/).
 
 - **[Hygiene and retrospective: different mechanisms](/unfold/notes/2026-04-20-hygiene-and-retrospective/)** (2026-04-20). Hygiene checks run before an action and verify state; retrospectives run after and capture learning. When something goes wrong the useful question is whether the fix is verifying-shaped or learning-shaped — retros cannot fix a hygiene-shaped problem.
 - **[Keeping `git status` load-bearing](/unfold/notes/2026-04-20-git-status-as-load-bearing-signal/)** (2026-04-20). `git status` is a signal with a signal-to-noise ratio. The fix is not more careful reading; it is `.gitignore` curation as recurring hygiene, so every untracked file either gets committed soon or disappears from the signal entirely.

--- a/tags.md
+++ b/tags.md
@@ -1,0 +1,24 @@
+---
+layout: page
+title: Tags
+permalink: /tags/
+---
+
+A clustering view of the notes. Every note is tagged with one or more short topic keywords — the sections below group notes by tag so adjacent observations live near each other. There is no formal taxonomy; tags are added as they arise, and the list will grow and shift as more notes accumulate.
+
+{% assign notes = site.pages | where: "dir", "/notes/" | where_exp: "p", "p.date != nil" %}
+{% assign all_tags = "" | split: "" %}
+{% for note in notes %}
+  {% assign all_tags = all_tags | concat: note.tags %}
+{% endfor %}
+{% assign unique_tags = all_tags | uniq | sort %}
+
+**Jump to:** {% for tag in unique_tags %}[{{ tag }}](#{{ tag | slugify }}){% unless forloop.last %} · {% endunless %}{% endfor %}
+
+{% for tag in unique_tags %}
+## {{ tag }}
+
+{% assign tag_notes = notes | where_exp: "n", "n.tags contains tag" | sort: "date" | reverse %}
+{% for note in tag_notes %}- [{{ note.title }}]({{ note.url | relative_url }}) ({{ note.date | date: "%Y-%m-%d" }})
+{% endfor %}
+{% endfor %}


### PR DESCRIPTION
## Summary
- New `tags.md` at repo root, published at `/unfold/tags/`, that iterates over every note, builds a unique sorted tag list, and lists the notes under each tag (newest-first).
- A "Jump to" anchor index at the top of the page for quick scanning.
- `notes/index.md` gets a "Browse by tag" link next to the RSS feed link so the page is discoverable.
- Left out of top-nav (`_config.yml` `header_pages`) — at 10 notes this is a clustering affordance, not a top-level destination. Can be promoted later if the note count grows.

## Why
Every note has tags backfilled (PR #17), but there was no affordance to browse by topic. CLAUDE.md explicitly anticipated this: *"no tag-navigation page yet, but the field is there so clustering can happen later without restructuring."* This is the "later."

## Implementation notes
Uses the same `site.pages | where: "dir", "/notes/" | where_exp: "p", "p.date != nil"` selector that `notes/feed.xml` already uses, so there's no new plugin dependency and no risk to the GitHub Pages build. Anchor IDs in the "Jump to" line use the `slugify` filter, which matches kramdown's default auto-id behaviour for heading text that already consists of lowercased hyphen-separated tokens.

## Test plan
- [ ] Wait for GitHub Pages to deploy; visit `/unfold/tags/` and verify all 13 unique tags render as sections with the expected notes underneath
- [ ] Click a few "Jump to" anchors and verify they scroll to the right section
- [ ] Visit `/unfold/notes/` and verify the new "Browse by tag" link resolves
- [ ] Confirm top-nav still shows only Framework and Notes — tags is reachable from notes index, not header

🤖 Generated with [Claude Code](https://claude.com/claude-code)