### PR TITLE
Fix notes selector: page.dir breaks under pretty permalinks

### DIFF
--- a/notes/feed.xml
+++ b/notes/feed.xml
@@ -11,7 +11,7 @@ permalink: /notes/feed.xml
   <atom:link href="{{ site.url }}{{ site.baseurl }}/notes/feed.xml" rel="self" type="application/rss+xml" />
   <language>en</language>
   <lastBuildDate>{{ site.time | date_to_rfc822 }}</lastBuildDate>
-{% assign notes = site.pages | where: "dir", "/notes/" | where_exp: "p", "p.date != nil" | sort: "date" | reverse %}
+{% assign notes = site.pages | where_exp: "p", "p.path contains 'notes/'" | where_exp: "p", "p.date != nil" | sort: "date" | reverse %}
 {% for note in notes %}
   <item>
     <title>{{ note.title | escape }}</title>

--- a/tags.md
+++ b/tags.md
@@ -6,7 +6,7 @@ permalink: /tags/
 
 A clustering view of the notes. Every note is tagged with one or more short topic keywords — the sections below group notes by tag so adjacent observations live near each other. There is no formal taxonomy; tags are added as they arise, and the list will grow and shift as more notes accumulate.
 
-{% assign notes = site.pages | where: "dir", "/notes/" | where_exp: "p", "p.date != nil" %}
+{% assign notes = site.pages | where_exp: "p", "p.path contains 'notes/'" | where_exp: "p", "p.date != nil" %}
 {% assign all_tags = "" | split: "" %}
 {% for note in notes %}
   {% assign all_tags = all_tags | concat: note.tags %}


### PR DESCRIPTION
## Summary
- Both `tags.md` and `notes/feed.xml` filtered `site.pages` with \`where: \"dir\", \"/notes/\"\`. With \`permalink: pretty\` in \`_config.yml\`, a note at \`notes/2026-04-20-foo.md\` gets URL \`/notes/2026-04-20-foo/\` and \`page.dir\` = \`/notes/2026-04-20-foo/\`, not \`/notes/\`. So the filter matched zero pages and both files silently rendered empty content.
- Switched to \`where_exp: \"p\", \"p.path contains 'notes/'\"\`. \`page.path\` is the source file path and is unaffected by permalink configuration.
- Fixes the tags page (PR #19, just merged) and also restores the RSS feed, which has been returning an empty channel since pretty permalinks were configured.

## How I noticed
Justin reported the live \`/unfold/tags/\` page showed the title and description but no tag sections. Pulling the rendered HTML confirmed \`unique_tags\` was empty. Pulling \`/unfold/notes/feed.xml\` confirmed the same bug was there, unnoticed.

## Test plan
- [ ] After this merges and Pages rebuilds, visit \`/unfold/tags/\` and verify all 13 unique tags render with the expected notes underneath
- [ ] Fetch \`/unfold/notes/feed.xml\` and verify it contains 10 \`<item>\` entries
- [ ] Click a few \"Jump to\" anchors on the tags page and verify they scroll correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)