### PR TITLE
Acknowledge SVPG product operating model in work-loops.md

### DIFF
--- a/framework/work-loops.md
+++ b/framework/work-loops.md
@@ -44,6 +44,8 @@ The retro-plan-sprint ceremony cadence is one specific timescale of this pattern
 
 ## Origin
 
+The three-loops framing is inspired by Marty Cagan's **product operating model**, as written up by [Silicon Valley Product Group](https://www.svpg.com/). SVPG's treatment of product discovery and delivery as distinct modes, and its emphasis on problem selection as its own concern, shaped the decomposition used here. The OODA overlay and the ceremony-cadence mapping are this project's additions.
+
 This framework was implicit in the project for some time before it was named. Two notes in the working material preceded and shaped this page:
 
 - [Loops inside loops: OODA at multiple scales](/unfold/notes/2026-04-11-nested-ooda-loops/) — the observation that the project's reflective practice runs OODA at several nested scales at once, and that the three-loops framing and retro-plan-sprint are two views of that nested structure.


### PR DESCRIPTION
## Summary
- Adds a short attribution paragraph to the top of the `## Origin` section on `framework/work-loops.md`, crediting Marty Cagan's product operating model (SVPG) as the source of the three-loops framing.
- External provenance (SVPG) now sits in front of internal provenance (the two preceding unfold notes), so a reader sees "adopted from" before "distilled within".
- Phrasing stays modest — "inspired by" / "shaped the decomposition" — since the unfold framing is influenced by SVPG but not a direct adoption; the OODA overlay and the ceremony-cadence mapping are this project's additions.

Closes the first action item in #20. The second action item (research SVPG material and pull in specific learnings — discovery vs. delivery, outcomes vs. outputs, empowered teams, continuous discovery) is separate, more exploratory work and will land in follow-up PRs so each idea lands as its own note or enrichment.

## Test plan
- [ ] `/framework/work-loops/` renders with the new paragraph at the top of the Origin section
- [ ] Link to svpg.com resolves
- [ ] No change to existing "implicit in the project" paragraph or the two note pointers

Refs #20